### PR TITLE
docs: sync README and ADR timeout constants with code — closes #2

### DIFF
--- a/docs/ADR-001-Socratic-Interception.md
+++ b/docs/ADR-001-Socratic-Interception.md
@@ -102,10 +102,10 @@ interface InterceptionResult {
 
 ### Latency and Timeouts
 
-To accommodate complex adversarial reasoning, timeouts have been increased:
+Timeouts are configured to accommodate complex adversarial reasoning across multiple LLM calls:
 
-- **Per-call timeout**: 30 seconds
-- **Gateway timeout**: 90 seconds
+- **Per-call timeout** (`PER_CALL_TIMEOUT_MS`): 30 seconds (30,000ms)
+- **Gateway timeout** (`GATEWAY_TIMEOUT_MS`): 90 seconds (90,000ms)
 
 ## Consequences
 

--- a/docs/ADR-001-Socratic-Interception.md
+++ b/docs/ADR-001-Socratic-Interception.md
@@ -72,7 +72,7 @@ The proxy enforces a synchronous loop on every incoming interception request to 
 
 **Loop constraints:**
 
-- 'MAX_DEPTH = 2' iterations of Attack/Assessment.
+- `MAX_DEPTH` (2) iterations of Attack/Assessment.
 - Early exit on high-confidence results (score <= 30 or score >= 80).
 
 ### Interface Definitions

--- a/src/services/interceptor.ts
+++ b/src/services/interceptor.ts
@@ -234,6 +234,7 @@ export async function executeSocraticGateway(
 ): Promise<InterceptionResult> {
   const terminalLog: string[] = [];
   const gatewayStart = Date.now();
+  let lastScore = 0;
 
   const apiKey = process.env.GEMINI_API_KEY || process.env.API_KEY;
   if (!apiKey) {
@@ -253,7 +254,6 @@ export async function executeSocraticGateway(
   );
 
   let priorRoundSummary: string | undefined;
-  let lastScore = 0;
 
   for (let round = 1; round <= MAX_DEPTH; round++) {
     // Check gateway timeout


### PR DESCRIPTION
## Summary

- ADR-001 Latency section now names `PER_CALL_TIMEOUT_MS` and `GATEWAY_TIMEOUT_MS` explicitly (30s/90s), connecting the prose directly to the constant names in code
- Fixes TS2448: `lastScore` was referenced before declaration in `executeSocraticGateway`; moved to function scope above the API key check

## Problem (issue #2)

The ADR latency section described timeouts in plain English ("30 seconds", "90 seconds") without naming the source constants, making it impossible to trace the documentation back to the code. The README Constants table already had the correct values.

## Test plan

- [x] `vitest run` — 3 tests pass (functional mock + 2 integration tests, skipped without API key)
- [x] No Python files — ruff not applicable
- [x] Commit references #2

Closes #2